### PR TITLE
Initial Upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
-all: init readme
+all: init docs/terraform.md readme
 
 test::
 	@echo "🚀 Starting tests..."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+
+
 <!-- markdownlint-disable -->
-<a href="https://cpco.io/homepage"><img src=".github/banner.png?raw=true" alt="Project Banner"/></a><br/>
+<a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/template/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
     <p align="right">
 <a href="https://github.com/cloudposse-terraform-components/template/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
 <!-- markdownlint-restore -->
@@ -25,38 +27,123 @@
 
 -->
 
-Description of this component
+This component creates subnet routes for a VPC.
 
 
----
-> [!NOTE]
-> This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=) approach towards DevOps.
-> <details><summary><strong>Learn More</strong></summary>
+> [!TIP]
+> #### 👽 Use Atmos with Terraform
+> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
+> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
 >
-> It's 100% Open Source and licensed under the [APACHE2](LICENSE).
->
-> </details>
+> <details>
+> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
+> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
+> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
+> </detalis>
 
-<a href="https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_header_link"><img src="https://cloudposse.com/readme/header/img"/></a>
 
 
 
 
 ## Usage
 
+**Stack Level**: Regional
 
-
-**Stack Level**: Regional or Test47
-
-Here's an example snippet for how to use this component.
+Here's a simple example using physical IDs:
 
 ```yaml
 components:
   terraform:
-    foo:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
       vars:
-        enabled: true
+        route_table_ids: ["rtb-0123456789abcdef0", "rtb-0123456789abcdef1"]
+        routes:
+          - destination:
+              cidr_block: "10.100.0.0/16"  # Target VPC CIDR
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
 ```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: !terraform.output vpc private_route_table_ids
+        routes:
+          - destination:
+              cidr_block: !terraform.output vpc target-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+```
+
+### Multiple Routes Example
+
+Example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: ["rtb-0123456789abcdef0"]
+        routes:
+          # Route to network account
+          - destination:
+              cidr_block: "10.0.0.0/16"
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
+          # Route to transit account
+          - destination:
+              cidr_block: "10.1.0.0/16"
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: !terraform.output vpc private_route_table_ids
+        routes:
+          # Route to network account
+          - destination:
+              cidr_block: !terraform.output vpc network-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+          # Route to transit account
+          - destination:
+              cidr_block: !terraform.output vpc transit-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+```
+
+> [!IMPORTANT]
+> In Cloud Posse's examples, we avoid pinning modules to specific versions to prevent discrepancies between the documentation
+> and the latest released versions. However, for your own projects, we strongly advise pinning each module to the exact version
+> you're using. This practice ensures the stability of your infrastructure. Additionally, we recommend implementing a systematic
+> approach for updating versions to avoid unexpected changes.
+
+
 
 
 
@@ -66,9 +153,7 @@ components:
 <!-- markdownlint-disable -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+No requirements.
 
 ## Providers
 
@@ -76,9 +161,7 @@ No providers.
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+No modules.
 
 ## Resources
 
@@ -86,32 +169,11 @@ No resources.
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+No inputs.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
+No outputs.
 <!-- markdownlint-restore -->
 
 
@@ -131,23 +193,60 @@ For additional context, refer to some of these links.
 - [Reference Architectures](https://cloudposse.com/) - Launch effortlessly with our turnkey reference architectures, built either by your team or ours.
 
 
+
+> [!TIP]
+> #### Use Terraform Reference Architectures for AWS
+>
+> Use Cloud Posse's ready-to-go [terraform architecture blueprints](https://cloudposse.com/reference-architecture/) for AWS to get up and running quickly.
+>
+> ✅ We build it together with your team.<br/>
+> ✅ Your team owns everything.<br/>
+> ✅ 100% Open Source and backed by fanatical support.<br/>
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <details><summary>📚 <strong>Learn More</strong></summary>
+>
+> <br/>
+>
+> Cloud Posse is the leading [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support) for funded startups and enterprises.
+>
+> *Your team can operate like a pro today.*
+>
+> Ensure that your team succeeds by using Cloud Posse's proven process and turnkey blueprints. Plus, we stick around until you succeed.
+> #### Day-0:  Your Foundation for Success
+> - **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
+> - **Deployment Strategy.** Adopt a proven deployment strategy with GitHub Actions, enabling automated, repeatable, and reliable software releases.
+> - **Site Reliability Engineering.** Gain total visibility into your applications and services with Datadog, ensuring high availability and performance.
+> - **Security Baseline.** Establish a secure environment from the start, with built-in governance, accountability, and comprehensive audit logs, safeguarding your operations.
+> - **GitOps.** Empower your team to manage infrastructure changes confidently and efficiently through Pull Requests, leveraging the full power of GitHub Actions.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+>
+> #### Day-2: Your Operational Mastery
+> - **Training.** Equip your team with the knowledge and skills to confidently manage the infrastructure, ensuring long-term success and self-sufficiency.
+> - **Support.** Benefit from a seamless communication over Slack with our experts, ensuring you have the support you need, whenever you need it.
+> - **Troubleshooting.** Access expert assistance to quickly resolve any operational challenges, minimizing downtime and maintaining business continuity.
+> - **Code Reviews.** Enhance your team’s code quality with our expert feedback, fostering continuous improvement and collaboration.
+> - **Bug Fixes.** Rely on our team to troubleshoot and resolve any issues, ensuring your systems run smoothly.
+> - **Migration Assistance.** Accelerate your migration process with our dedicated support, minimizing disruption and speeding up time-to-value.
+> - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
+>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> </details>
+
 ## ✨ Contributing
 
 This project is under active development, and we encourage contributions from our community.
+
+
+
 Many thanks to our outstanding contributors:
 
 <a href="https://github.com/cloudposse-terraform-components/template/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/template&max=24" />
 </a>
 
-### 🐛 Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse-terraform-components/template/issues) to report any bugs or file feature requests.
-
-### 💻 Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or help out with Cloud Posse's other projects, we would love to hear from you!
-Hit us up in [Slack](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack), in the `#cloudposse` channel.
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse-terraform-components/template/issues).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
  1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/template/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
@@ -172,38 +271,6 @@ Dropped straight into your Inbox every week — and usually a 5-minute read.
 
 [Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
 It's **FREE** for everyone!
-
-## About
-
-This project is maintained by <a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=">Cloud Posse, LLC</a>.
-<a href="https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content="><img src="https://cloudposse.com/logo-300x69.svg" align="right" /></a>
-
-We are a [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support) for funded startups and enterprises.
-Use our ready-to-go terraform architecture blueprints for AWS to get up and running quickly.
-We build it with you. You own everything. Your team wins. Plus, we stick around until you succeed.
-
-<a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Learn More" src="https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge"/></a>
-
-*Your team can operate like a pro today.*
-
-Ensure that your team succeeds by using our proven process and turnkey blueprints. Plus, we stick around until you succeed.
-
-<details>
-  <summary>📚 <strong>See What's Included</strong></summary>
-
-- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
-- **Deployment Strategy.** You'll have a battle-tested deployment strategy using GitHub Actions that's automated and repeatable.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
-- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
-- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
-- **Training.** You'll receive hands-on training so your team can operate what we build.
-- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
-- **Troubleshooting.** You'll get help to triage when things aren't working.
-- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
-- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
-</details>
-
-<a href="https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_commercial_support_link"><img src="https://cloudposse.com/readme/commercial-support/img"/></a>
 ## License
 
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="License"></a>
@@ -238,8 +305,10 @@ under the License.
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
+
+
 ---
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>

--- a/README.yaml
+++ b/README.yaml
@@ -1,23 +1,101 @@
-name: "template"
+name: "aws-vpc-routes"
 
 # Canonical GitHub repo
 github_repo: "cloudposse-terraform-components/template"
 
 # Short description of this project
 description: |-
-  Description of this component
+  This component creates subnet routes for a VPC.
 
 usage: |-
-  **Stack Level**: Regional or Test47
+  **Stack Level**: Regional
 
-  Here's an example snippet for how to use this component.
-  
+  Here's a simple example using physical IDs:
+
   ```yaml
   components:
     terraform:
-      foo:
+      vpc/routes/private:
+        metadata:
+          component: vpc-routes
         vars:
-          enabled: true
+          route_table_ids: ["rtb-0123456789abcdef0", "rtb-0123456789abcdef1"]
+          routes:
+            - destination:
+                cidr_block: "10.100.0.0/16"  # Target VPC CIDR
+              target:
+                type: transit_gateway_id
+                value: "tgw-0123456789abcdef0"
+  ```
+
+  The same configuration using terraform outputs:
+
+  ```yaml
+  components:
+    terraform:
+      vpc/routes/private:
+        metadata:
+          component: vpc-routes
+        vars:
+          route_table_ids: !terraform.output vpc private_route_table_ids
+          routes:
+            - destination:
+                cidr_block: !terraform.output vpc target-vpc vpc_cidr
+              target:
+                type: transit_gateway_id
+                value: !terraform.output tgw/hub transit_gateway_id
+  ```
+
+  ### Multiple Routes Example
+
+  Example using physical IDs:
+
+  ```yaml
+  components:
+    terraform:
+      vpc/routes/private:
+        metadata:
+          component: vpc-routes
+        vars:
+          route_table_ids: ["rtb-0123456789abcdef0"]
+          routes:
+            # Route to network account
+            - destination:
+                cidr_block: "10.0.0.0/16"
+              target:
+                type: transit_gateway_id
+                value: "tgw-0123456789abcdef0"
+            # Route to transit account
+            - destination:
+                cidr_block: "10.1.0.0/16"
+              target:
+                type: transit_gateway_id
+                value: "tgw-0123456789abcdef0"
+  ```
+
+  The same configuration using terraform outputs:
+
+  ```yaml
+  components:
+    terraform:
+      vpc/routes/private:
+        metadata:
+          component: vpc-routes
+        vars:
+          route_table_ids: !terraform.output vpc private_route_table_ids
+          routes:
+            # Route to network account
+            - destination:
+                cidr_block: !terraform.output vpc network-vpc vpc_cidr
+              target:
+                type: transit_gateway_id
+                value: !terraform.output tgw/hub transit_gateway_id
+            # Route to transit account
+            - destination:
+                cidr_block: !terraform.output vpc transit-vpc vpc_cidr
+              target:
+                type: transit_gateway_id
+                value: !terraform.output tgw/hub transit_gateway_id
   ```
 
 include:

--- a/src/README.md
+++ b/src/README.md
@@ -108,28 +108,6 @@ components:
               value: !terraform.output tgw/hub transit_gateway_id
 ```
 
-### Common Use Cases
-
-1. **Transit Gateway Routing**: Configure routes to direct traffic through Transit Gateways for inter-VPC communication
-2. **Environment Connectivity**: Set up routes between different environments (dev, staging, prod)
-3. **Shared Services Access**: Enable access to shared services in transit or core accounts
-
-## Best Practices
-
-1. **Route Organization**: Split routes into logical components (e.g., by environment or purpose) to:
-   - Improve maintainability
-   - Reduce deployment time
-   - Minimize blast radius of changes
-
-2. **Naming Convention**: Use clear naming for route components, for example:
-   ```
-   vpc/routes/private/transit  # Routes to transit network
-   vpc/routes/private/dev      # Routes to dev environment
-   vpc/routes/private/prod     # Routes to prod environment
-   ```
-
-3. **Documentation**: Always document the purpose of route configurations in component metadata or comments
-
 <!-- prettier-ignore-start -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,201 @@
+---
+tags:
+  - component/vpc-routes
+  - layer/network
+  - provider/aws
+---
+
+# Component: `vpc-routes`
+
+This component is responsible for provisioning routes in VPC route tables. It's commonly used to configure routing between VPCs through Transit Gateways.
+
+## Usage
+
+**Stack Level**: Regional
+
+This component is deployed to each region where VPC routing needs to be configured. It's particularly useful for:
+- Configuring routes between VPCs through Transit Gateways
+- Managing multiple route tables with similar route configurations
+- Separating route configurations for better maintainability and reduced blast radius
+
+### Basic Example
+
+Here's a simple example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: ["rtb-0123456789abcdef0", "rtb-0123456789abcdef1"]
+        routes:
+          - destination:
+              cidr_block: "10.100.0.0/16"  # Target VPC CIDR
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: !terraform.output vpc private_route_table_ids
+        routes:
+          - destination:
+              cidr_block: !terraform.output vpc target-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+```
+
+### Multiple Routes Example
+
+Example using physical IDs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: ["rtb-0123456789abcdef0"]
+        routes:
+          # Route to network account
+          - destination:
+              cidr_block: "10.0.0.0/16"
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
+          # Route to transit account
+          - destination:
+              cidr_block: "10.1.0.0/16"
+            target:
+              type: transit_gateway_id
+              value: "tgw-0123456789abcdef0"
+```
+
+The same configuration using terraform outputs:
+
+```yaml
+components:
+  terraform:
+    vpc/routes/private:
+      metadata:
+        component: vpc-routes
+      vars:
+        route_table_ids: !terraform.output vpc private_route_table_ids
+        routes:
+          # Route to network account
+          - destination:
+              cidr_block: !terraform.output vpc network-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+          # Route to transit account
+          - destination:
+              cidr_block: !terraform.output vpc transit-vpc vpc_cidr
+            target:
+              type: transit_gateway_id
+              value: !terraform.output tgw/hub transit_gateway_id
+```
+
+### Common Use Cases
+
+1. **Transit Gateway Routing**: Configure routes to direct traffic through Transit Gateways for inter-VPC communication
+2. **Environment Connectivity**: Set up routes between different environments (dev, staging, prod)
+3. **Shared Services Access**: Enable access to shared services in transit or core accounts
+
+## Best Practices
+
+1. **Route Organization**: Split routes into logical components (e.g., by environment or purpose) to:
+   - Improve maintainability
+   - Reduce deployment time
+   - Minimize blast radius of changes
+
+2. **Naming Convention**: Use clear naming for route components, for example:
+   ```
+   vpc/routes/private/transit  # Routes to transit network
+   vpc/routes/private/dev      # Routes to dev environment
+   vpc/routes/private/prod     # Routes to prod environment
+   ```
+
+3. **Documentation**: Always document the purpose of route configurations in component metadata or comments
+
+<!-- prettier-ignore-start -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_route_table_ids"></a> [route\_table\_ids](#input\_route\_table\_ids) | List of route table IDs | `list(string)` | `[]` | no |
+| <a name="input_routes"></a> [routes](#input\_routes) | A list of route objects to add to route tables. Each route object has a destination and a target. | <pre>list(object({<br/>    destination = object({<br/>      cidr_block = string<br/>    })<br/>    target = object({<br/>      type  = string<br/>      value = optional(string, "")<br/>    })<br/>  }))</pre> | `[]` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- prettier-ignore-end -->
+
+## References
+
+- [AWS VPC Route Tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html)
+- [Transit Gateway Route Tables](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-route-tables.html)
+- [cloudposse/terraform-aws-components](TODO) - Cloud Posse's upstream component
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,7 +2,19 @@ locals {
   enabled = module.this.enabled
 }
 
+resource "aws_route" "this" {
+  for_each = local.enabled ? {
+    for pair in setproduct(var.route_table_ids, var.routes) : "${pair[0]}-${pair[1].destination.cidr_block}" => {
+      route_table_id         = pair[0]
+      destination_cidr_block = pair[1].destination.cidr_block
+      target                 = pair[1].target
+    }
+  } : {}
 
+  route_table_id         = each.value.route_table_id
+  destination_cidr_block = each.value.destination_cidr_block
 
-
-
+  # Exactly one of the following options should be given
+  transit_gateway_id = each.value.target.type == "transit_gateway_id" ? each.value.target.value : null
+  nat_gateway_id     = each.value.target.type == "nat_gateway_id" ? each.value.target.value : null
+}

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = var.region
+
+  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
+  profile = module.iam_roles.terraform_profile_name
+
+  dynamic "assume_role" {
+    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
+    for_each = compact([module.iam_roles.terraform_role_arn])
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "route_table_ids" {
+  type        = list(string)
+  description = "List of route table IDs"
+  default     = []
+}
+
+variable "routes" {
+  type = list(object({
+    destination = object({
+      cidr_block = string
+    })
+    target = object({
+      type  = string
+      value = optional(string, "")
+    })
+  }))
+
+  description = <<-EOF
+  A list of route objects to add to route tables. Each route object has a destination and a target.
+  EOF
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for route in var.routes : contains(["transit_gateway_id", "nat_gateway_id"], route.target.type)
+    ])
+    error_message = "Target type must be transit_gateway_id or nat_gateway_id"
+  }
+}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,10 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  required_providers {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.1"
+    }
+  }
 }


### PR DESCRIPTION
## what
- Upstream initial implementation
- `aws-tgw-hub`, `aws-tgw-routes`, `aws-tgw-attachment`, `aws-vpc-routes` are very closely tied together. Creating all now

## why
- We do not have the public documentation for docs.cloudposse ready yet, but we want to make what we do have available
- These improvements have come up in discussion more than once, so let's push it up

## references
- https://github.com/orgs/cloudposse/discussions/31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new component for creating subnet routes in AWS VPC
	- Supports configuring routes using Transit Gateways and NAT Gateways

- **Documentation**
	- Updated README with detailed usage examples and component description
	- Clarified project purpose and implementation details

- **Chores**
	- Updated copyright year to 2025
	- Refined project configuration and provider settings

- **Infrastructure**
	- Implemented flexible route table and route configuration mechanism
	- Added support for regional route management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->